### PR TITLE
カード登録・詳細表示ページのマークアップ

### DIFF
--- a/app/assets/javascripts/payjp.js
+++ b/app/assets/javascripts/payjp.js
@@ -1,36 +1,34 @@
-window.addEventListener('DOMContentLoaded', function(){
-
-  //id名が"payment_card_submit-button"というボタンが押されたら取得
-  let submit = document.getElementById("payment_card_submit-button");
-
-  Payjp.setPublicKey('pk_test_07badb8acc00722abed1baf3'); 
-
-    submit.addEventListener('click', function(e){ //ボタンが押されたらトークン作成開始。
-
-    e.preventDefault(); //ボタンを1度無効化
-
-    let card = { //入力されたカード情報を取得(id名の記載ミスに注意！)
-        number: document.getElementById("payment_card_no").value,
-        cvc: document.getElementById("payment_card_cvc").value,
-        exp_month: document.getElementById("payment_card_month").value,
-        exp_year: document.getElementById("payment_card_year").value
-    };
-
-    Payjp.createToken(card, function(status, response) {  // トークンを生成
-      if (status === 200) { //成功した場合(status === 200はリクエストが成功している状況です。)
-        //データを自サーバにpostしないようにremoveAttr("name")で削除
-        $(".number").removeAttr("name");
-        $(".cvc").removeAttr("name");
-        $(".exp_month").removeAttr("name");
-        $(".exp_year").removeAttr("name"); 
-        $("#charge-form").append(
-          $('<input type="hidden" name="payjp_token">').val(response.id)
-        ); //取得したトークンを送信できる状態にします
-        document.inputForm.submit();
-        alert("登録が完了しました");
-      } else {
-        alert("カード情報が正しくありません。"); //エラー確認用
-      }
-    });
-  });
-});
+document.addEventListener(
+  "DOMContentLoaded", e => {
+    if (document.getElementById("token_submit") != null) { //token_submitというidがnullの場合、下記コードを実行しない
+      Payjp.setPublicKey("pk_test_07badb8acc00722abed1baf3"); //ここに公開鍵を直書き
+      let btn = document.getElementById("token_submit"); //IDがtoken_submitの場合に取得されます
+      btn.addEventListener("click", e => { //ボタンが押されたときに作動します
+        e.preventDefault(); //ボタンを一旦無効化します
+        let card = {
+          number: document.getElementById("card_number").value,
+          cvc: document.getElementById("cvc").value,
+          exp_month: document.getElementById("exp_month").value,
+          exp_year: document.getElementById("exp_year").value
+        }; //入力されたデータを取得します。
+        Payjp.createToken(card, (status, response) => {
+          if (status === 200) { //成功した場合
+            $("#card_number").removeAttr("name");
+            $("#cvc").removeAttr("name");
+            $("#exp_month").removeAttr("name");
+            $("#exp_year").removeAttr("name"); //データを自サーバにpostしないように削除
+            $("#card_token").append(
+              $('<input type="hidden" name="payjp_token">').val(response.id)
+            ); //取得したトークンを送信できる状態にします
+            $("#charge-form")[0].submit()
+            
+            alert("登録が完了しました"); //確認用
+          } else {
+            alert("カード情報が正しくありません。"); //確認用
+          }
+        });
+      });
+    }
+  },
+  false
+);

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,3 +1,4 @@
+= render "items/header"
 .Mypage-main
   .Mypage-main__contents
     %section.Register
@@ -12,10 +13,6 @@
             JCB、Diners Club、Discover
             %br
           = form_with url: cards_path, method: :post, id: "charge-form", name: "inputForm" do |f|
-            .Register__form__content__group
-              %label.Register__form__content__group__label カード番号
-              %span.Register__form__content__group__necessary 必須
-              = f.text_field :number, name: "card_number", id:"card_number", type: "text", placeholder: '半角数字のみ', class: 'Register__form__content__group__input', maxlength: "16"
             .Register__form__content__group
               %label.Register__form__content__group__label カード番号
               %span.Register__form__content__group__necessary 必須
@@ -38,3 +35,4 @@
               %span.Register__form__content__group__necessary 必須
               = f.text_field :cvc, name: "cvc", id:"cvc", class:"cvc", type: "text", placeholder: 'カード背面4桁もしくは3桁の番号', class: 'Register__form__content__group__input', maxlength: "4"
               = f.submit "追加する", class: "Register__form__content__btn",  id: "token_submit"
+= render "items/footer"

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -1,61 +1,40 @@
-.card_add
-  .title クレジットカード情報入力
-
-  = form_tag(cards_path, method: :post, id: "charge-form", class: "details", name: "inputForm") do
-    .number-details
-      .card-number カード番号
-      %span.must_check 必須
-    .number
-      = text_field_tag 'payment_card_no', "", class: 'cardnumber', id: "payment_card_no", placeholder: '半角数字のみ', type: "text", maxlength: "16"
-    .image
-      = image_tag(image_path('cards/visa.png'), class: 'visa')
-      = image_tag(image_path('cards/master.png'), class: 'master')
-      = image_tag(image_path('cards/jcb.png'), class: 'jcb')
-      = image_tag(image_path('cards/amex.png'), class: 'amex')
-      = image_tag(image_path('cards/diners.png'), class: 'diners')
-      = image_tag(image_path('cards/discover.png'), class: 'discover')
-
-    .expirationdate
-      .expirationdate__details
-        .date 有効期限
-        %span.must_check 必須
-      .expirationdate__choice
-        .month
-          %select#payment_card_month.card-default{name: "payment_card_month", type: "text"}
-            %option{value: "1"} 01
-            %option{value: "2"} 02
-            %option{value: "3"} 03
-            %option{value: "4"} 04
-            %option{value: "5"} 05
-            %option{value: "6"} 06
-            %option{value: "7"} 07
-            %option{value: "8"} 08
-            %option{value: "9"} 09
-            %option{value: "10"} 10
-            %option{value: "11"} 11
-            %option{value: "12"} 12
-          .month-details 月
-        .year
-          %select#payment_card_year.card-default{name: "payment_card_year", type: "text"}
-            %option{value: "2020"} 20
-            %option{value: "2021"} 21
-            %option{value: "2022"} 22
-            %option{value: "2023"} 23
-            %option{value: "2024"} 24
-            %option{value: "2025"} 25
-            %option{value: "2026"} 26
-            %option{value: "2027"} 27
-            %option{value: "2028"} 28
-            %option{value: "2029"} 29
-            %option{value: "2030"} 30
-          .year-details 年
-
-    .securitycode
-      .securitycode__details
-        .securitycode-details__title セキュリティコード
-        %span.must_check 必須
-      .securitycode__cardsecurity
-        = text_field_tag  "payment_card_cvc", "", type: 'text', class: 'securitycode__cardsecurity__form', id: "payment_card_cvc", maxlength: "4", placeholder: 'カード背面4桁もしくは3桁の番号'
-      .card-question カード裏面の番号とは？
-    .add
-      = submit_tag "登録する", class: "add__btn", id: "payment_card_submit-button"
+.Mypage-main
+  .Mypage-main__contents
+    %section.Register
+      %h2.Register__head クレジットカード情報入力
+      .Register__form
+        .Register__form__content
+          %p.Register__form__content__card
+            ※登録可能カード
+            %br
+            Visa , Mastercard , American Express
+            %br
+            JCB、Diners Club、Discover
+            %br
+          = form_with url: cards_path, method: :post, id: "charge-form", name: "inputForm" do |f|
+            .Register__form__content__group
+              %label.Register__form__content__group__label カード番号
+              %span.Register__form__content__group__necessary 必須
+              = f.text_field :number, name: "card_number", id:"card_number", type: "text", placeholder: '半角数字のみ', class: 'Register__form__content__group__input', maxlength: "16"
+            .Register__form__content__group
+              %label.Register__form__content__group__label カード番号
+              %span.Register__form__content__group__necessary 必須
+              = f.text_field :number, name: "card_number", id:"card_number", type: "text", placeholder: '半角数字のみ', class: 'Register__form__content__group__input', maxlength: "16"
+            .Register__form__content__group
+              %label.Register__form__content__group__label 有効期限
+              %span.Register__form__content__group__necessary 必須
+              %br
+              .Register__form__content__group__half
+                = f.select :exp_month, [["01",1],["02",2],["03",3],["04",4],["05",5],["06",6],["07",7],["08",8],["09",9],["10",10],["11",11],["12",12]], {}, class: 'Register__form__content__group__half__select', name: "exp_year", id:"exp_month"
+                = icon('fas', 'angle-down')
+                %span 月
+              .Register__form__content__group__half
+                = f.select :exp_year, [["20",2020],["21",2021],["22",2022],["23",2023],["24",2024],["25",2025],["26",2026],["27",2027],["28",2028],["29",2029],["30",2030]], {}, class: 'Register__form__content__group__half__select', name: "exp_year", id:"exp_year"
+                = icon('fas', 'angle-down')
+                %span 年
+            #card_token
+            .Register__form__content__group
+              %label.Register__form__content__group__label セキュリティコード
+              %span.Register__form__content__group__necessary 必須
+              = f.text_field :cvc, name: "cvc", id:"cvc", class:"cvc", type: "text", placeholder: 'カード背面4桁もしくは3桁の番号', class: 'Register__form__content__group__input', maxlength: "4"
+              = f.submit "追加する", class: "Register__form__content__btn",  id: "token_submit"

--- a/app/views/cards/show.html.haml
+++ b/app/views/cards/show.html.haml
@@ -1,25 +1,13 @@
-.show
-  .show__frame
-    .show__frame__title
-      登録クレジットカード情報
-    .credit_card__list
-      .credit_card__list__title
-        クレジットカード一覧
-      .credit_card__list__frame
-        .credit_card_info
-          .credit_card_info__brand
-            = image_tag "cards/#{@card_src}", class: "card_info__brand__img", alt: @card_brand
-          .credit_card_info__numbers
-            .number
-              = "**** **** **** " + @customer_card.last4
-            .expiration_date
-              .expiration_date__title
-                有効期限
-              .expiration_date__info
-                = @exp_month + " / " + @exp_year
-        .destroy__function
-          .destroy__function__link
-            = link_to card_path, method: :delete, class: "destroy__function__link__btn" do
-              削除する
-      .payment-details
-        = link_to "支払い方法について >", "", class: "payment-details__btn"
+.Mypage-main
+  = render "items/header"
+  .Mypage-main__contents.card-form
+    %h2.Payment__head 登録クレジットカード情報
+    %br
+    = "**** **** **** " + @customer_card.last4
+    %br
+    -# - exp_month = @default_card_information.exp_month.to_s
+    -# - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+    = @exp_month + " / " + @exp_year
+    = form_with url: card_path, method: :delete, id: 'charge-form', name: "inputForm", local: true do |f|
+      = f.submit "削除する", class: 'card-delete-btn'
+  = render "items/footer"


### PR DESCRIPTION
# What
マイページからクレジットカードの登録・詳細表示・削除ができる。

# Why
商品購入を行うためには、クレジットカードの登録が必須であるため。

<img width="1440" alt="スクリーンショット 2020-10-28 23 18 11" src="https://user-images.githubusercontent.com/67492329/97448301-dcb95900-1973-11eb-8451-ee3d57daac51.png">
<img width="1440" alt="スクリーンショット 2020-10-28 23 18 48" src="https://user-images.githubusercontent.com/67492329/97448373-f0fd5600-1973-11eb-910b-ffc9ef8e9d88.png">
<img width="1440" alt="スクリーンショット 2020-10-28 23 19 01" src="https://user-images.githubusercontent.com/67492329/97448416-f9ee2780-1973-11eb-8177-224734592c56.png">
<img width="1440" alt="スクリーンショット 2020-10-28 23 38 27" src="https://user-images.githubusercontent.com/67492329/97451022-afba7580-1976-11eb-95f4-5d60b3bbcad3.png">


